### PR TITLE
Fix cube pack generation post Cubecobra API update

### DIFF
--- a/boostertutor/generator.py
+++ b/boostertutor/generator.py
@@ -184,7 +184,7 @@ class MtgPackGenerator:
         return [self.get_cube_pack(cube) for _ in range(n)]
 
     def get_cube_pack(self, cube: dict) -> MtgPack:
-        logger.debug(f"Generating {cube['shortID']} cube pack...")
+        logger.debug(f"Generating {cube['shortId']} cube pack...")
         cube_name = cube["name"]
         try:
             slots = []
@@ -197,14 +197,14 @@ class MtgPackGenerator:
             replace = cube["formats"][0]["multiples"]
 
             cube_cards: dict[str, list[str]] = {key: [] for key in pack_format}
-            for card in cube["cards"]:
+            for card in cube["cards"]["mainboard"]:
                 if card["tags"] and card["tags"][0] in cube_cards:
                     cube_cards[card["tags"][0]].append(card)
         except (KeyError, IndexError, AssertionError) as e:
             logger.debug(e, exc_info=True)
             pack_format = {"cards": 15}
             replace = False
-            cube_cards = {"cards": cube["cards"]}
+            cube_cards = {"cards": cube["cards"]["mainboard"]}
         logger.debug(f"Using pack format: {pack_format}")
 
         pack_list = []
@@ -218,7 +218,7 @@ class MtgPackGenerator:
             )
             for card_dict in pack_list
         ]
-        logger.info(f"{cube['shortID']} cube pack generated")
+        logger.info(f"{cube['shortId']} cube pack generated")
         return MtgPack(
             {"pack": {"cards": pack_cards, "balance": False}}, name=cube_name
         )

--- a/boostertutor/generator.py
+++ b/boostertutor/generator.py
@@ -188,13 +188,13 @@ class MtgPackGenerator:
         cube_name = cube["name"]
         try:
             slots = []
-            for slot in cube["draft_formats"][0]["packs"][0]["slots"]:
+            for slot in cube["formats"][0]["packs"][0]["slots"]:
                 assert slot.startswith("tag:") or slot.startswith("t:")
                 slots.append(slot.split(":")[1].strip('"'))
             pack_format: dict[str, int] = Counter(slots)
             logger.debug(f"Pack format: {pack_format}")
 
-            replace = cube["draft_formats"][0]["multiples"]
+            replace = cube["formats"][0]["multiples"]
 
             cube_cards: dict[str, list[str]] = {key: [] for key in pack_format}
             for card in cube["cards"]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,84 +88,86 @@ def unbalanced_pack(generator: MtgPackGenerator) -> MtgPack:
 def cube() -> dict:
     return {
         "name": "Test Cube",
-        "shortID": "test_cube",
-        "cards": [
-            {
-                "cardID": "fb9cd7d9-8aad-4607-890c-9c8efe016a92",
-                "finish": "Non-foil",
-                "tags": ["Double"],
-            },
-            {
-                "cardID": "9797c813-0cda-44ad-ae41-330e9bde9cb9",
-                "finish": "Non-foil",
-                "tags": ["Non-foil"],
-            },
-            {
-                "cardID": "a9d6bd19-77c9-4a1a-a2d5-6f9737693fea",
-                "finish": "Non-foil",
-                "tags": ["Non-foil"],
-            },
-            {
-                "cardID": "e312653d-c3e1-4c79-90d2-0963419b618c",
-                "finish": "Non-foil",
-                "tags": ["Non-foil"],
-            },
-            {
-                "cardID": "c1718028-3009-4bdd-9f6f-59c17edd1344",
-                "finish": "Non-foil",
-                "tags": ["Non-foil"],
-            },
-            {
-                "cardID": "f3da5010-78b6-426f-aeb4-73c21d2af581",
-                "finish": "Non-foil",
-                "tags": ["Non-foil"],
-            },
-            {
-                "cardID": "868efcee-bb13-4b6f-b81b-99408685e4c4",
-                "finish": "Non-foil",
-                "tags": ["Non-foil"],
-            },
-            {
-                "cardID": "c12529e4-f4b1-45be-8252-28783badbec5",
-                "finish": "Non-foil",
-                "tags": ["Non-foil"],
-            },
-            {
-                "cardID": "9621f341-bf85-4b77-bf19-2fb013b4c955",
-                "finish": "Non-foil",
-                "tags": ["Non-foil"],
-            },
-            {
-                "cardID": "39514d54-cb6c-4b3b-a3be-46db991be4d4",
-                "finish": "Non-foil",
-                "tags": ["Non-foil"],
-            },
-            {
-                "cardID": "3a4d395e-d7d6-4e93-9761-b0bae63b7b1c",
-                "finish": "Non-foil",
-                "tags": ["Non-foil"],
-            },
-            {
-                "cardID": "54c76a22-f9e3-408b-a5bd-403add57e31a",
-                "finish": "Non-foil",
-                "tags": ["Non-foil"],
-            },
-            {
-                "cardID": "35b3da05-9a3e-4827-96b8-5de244128db3",
-                "finish": "Non-foil",
-                "tags": [],
-            },
-            {
-                "cardID": "a7af8350-9a51-437c-a55e-19f3e07acfa9",
-                "finish": "Etched",
-                "tags": ["Etched"],
-            },
-            {
-                "cardID": "39dce974-846f-4365-b0a5-851e38668e7d",
-                "finish": "Foil",
-                "tags": ["Foil"],
-            },
-        ],
+        "shortId": "test_cube",
+        "cards": {
+            "mainboard": [
+                {
+                    "cardID": "fb9cd7d9-8aad-4607-890c-9c8efe016a92",
+                    "finish": "Non-foil",
+                    "tags": ["Double"],
+                },
+                {
+                    "cardID": "9797c813-0cda-44ad-ae41-330e9bde9cb9",
+                    "finish": "Non-foil",
+                    "tags": ["Non-foil"],
+                },
+                {
+                    "cardID": "a9d6bd19-77c9-4a1a-a2d5-6f9737693fea",
+                    "finish": "Non-foil",
+                    "tags": ["Non-foil"],
+                },
+                {
+                    "cardID": "e312653d-c3e1-4c79-90d2-0963419b618c",
+                    "finish": "Non-foil",
+                    "tags": ["Non-foil"],
+                },
+                {
+                    "cardID": "c1718028-3009-4bdd-9f6f-59c17edd1344",
+                    "finish": "Non-foil",
+                    "tags": ["Non-foil"],
+                },
+                {
+                    "cardID": "f3da5010-78b6-426f-aeb4-73c21d2af581",
+                    "finish": "Non-foil",
+                    "tags": ["Non-foil"],
+                },
+                {
+                    "cardID": "868efcee-bb13-4b6f-b81b-99408685e4c4",
+                    "finish": "Non-foil",
+                    "tags": ["Non-foil"],
+                },
+                {
+                    "cardID": "c12529e4-f4b1-45be-8252-28783badbec5",
+                    "finish": "Non-foil",
+                    "tags": ["Non-foil"],
+                },
+                {
+                    "cardID": "9621f341-bf85-4b77-bf19-2fb013b4c955",
+                    "finish": "Non-foil",
+                    "tags": ["Non-foil"],
+                },
+                {
+                    "cardID": "39514d54-cb6c-4b3b-a3be-46db991be4d4",
+                    "finish": "Non-foil",
+                    "tags": ["Non-foil"],
+                },
+                {
+                    "cardID": "3a4d395e-d7d6-4e93-9761-b0bae63b7b1c",
+                    "finish": "Non-foil",
+                    "tags": ["Non-foil"],
+                },
+                {
+                    "cardID": "54c76a22-f9e3-408b-a5bd-403add57e31a",
+                    "finish": "Non-foil",
+                    "tags": ["Non-foil"],
+                },
+                {
+                    "cardID": "35b3da05-9a3e-4827-96b8-5de244128db3",
+                    "finish": "Non-foil",
+                    "tags": [],
+                },
+                {
+                    "cardID": "a7af8350-9a51-437c-a55e-19f3e07acfa9",
+                    "finish": "Etched",
+                    "tags": ["Etched"],
+                },
+                {
+                    "cardID": "39dce974-846f-4365-b0a5-851e38668e7d",
+                    "finish": "Foil",
+                    "tags": ["Foil"],
+                },
+            ]
+        },
     }
 
 

--- a/tests/generator_test.py
+++ b/tests/generator_test.py
@@ -196,7 +196,7 @@ def test_cube_pack_custom(
     expected_len: int,
     expected_dups: bool,
 ):
-    cube["draft_formats"] = [draft_format]
+    cube["formats"] = [draft_format]
     p = generator.get_cube_pack(cube)
     copy_count = Counter([c.card.name for c in p.cards])
     assert len(p.cards) == expected_len


### PR DESCRIPTION
`draft-formats` changed to `formats` in cubecobra's API, breaking compatibility.